### PR TITLE
chore: set up CI/CD pipeline for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.13.2'
+
+      - name: Install dependencies
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+
+      - name: Deploy to EC2 via SSH
+        env:
+          PRIVATE_KEY: ${{ secrets.EC2_PRIVATE_KEY }}
+          HOST: ${{ secrets.EC2_HOST }}
+          USERNAME: ubuntu  
+        run: |
+          echo "$PRIVATE_KEY" > private_key.pem
+          chmod 600 private_key.pem
+          ssh -i private_key.pem $USERNAME@$HOST "cd /path/to/project && git pull && source venv/bin/activate && uvicorn main:app --host 0.0.0.0 --port 8000 --reload"


### PR DESCRIPTION
- Added the `deploy.yaml` file to set up the Continuous Deployment (CD) pipeline for automated deployment to AWS EC2.
- The task requires setting up a CD pipeline that automatically deploys the FastAPI application when changes are merged into the `main` branch. This aligns with the project’s goal of automating deployments via GitHub Actions.

Test

- The CI pipeline was already tested with pytest, ensuring that tests run correctly on pull requests.
- Manual testing of the deployment process will be conducted after merging this PR, verifying if the application deploys successfully to AWS EC2.